### PR TITLE
Include cryptsetup and nvme-cli to linstor-satellite docker image

### DIFF
--- a/dockerfiles/linstor-satellite/Dockerfile
+++ b/dockerfiles/linstor-satellite/Dockerfile
@@ -17,7 +17,7 @@ ENV TINI_VERSION v0.18.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 ENTRYPOINT ["/tini", "--"]
- 
+
 # Install linstor-satellite
 RUN apt-get update \
  && apt-get install -y linstor-satellite drbd-utils \
@@ -26,7 +26,7 @@ RUN apt-get update \
 
 # Install additional tools
 RUN apt-get update \
- && apt-get install -y kmod zfsutils-linux thin-provisioning-tools \
+ && apt-get install -y kmod zfsutils-linux thin-provisioning-tools cryptsetup nvme-cli \
  && apt-get download lvm2 \
  && dpkg --unpack lvm2*.deb \
  && rm -f lvm2*.deb /var/lib/dpkg/info/lvm2.postinst \


### PR DESCRIPTION
## What

* Include cryptsetup and nvme-cli to linstor-satellite docker image

## Why

* Enable luks and nvme supported resource layers

```
    Unsupported resource layers:
        LUKS: IO exception occured when running 'cryptsetup --version': Cannot run program "cryptsetup": error=2, No such file or directory
        NVME: IO exception occured when running 'nvme version': Cannot run program "nvme": error=2, No such file or directory
```