### PR TITLE
Add RBAC to satellite daemonset

### DIFF
--- a/helm/kube-linstor/templates/controller-rbac.yaml
+++ b/helm/kube-linstor/templates/controller-rbac.yaml
@@ -16,6 +16,10 @@ rules:
   - apiGroups: [""]
     resources: ["endpoints", "endpoints/restricted"]
     verbs: ["create", "patch", "update"]
+  - apiGroups: ["extensions"]
+    resources: ["podsecuritypolicies"]
+    resourceNames: ["{{ $fullName }}"]
+    verbs: ["use"]
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/kube-linstor/templates/controller-rbac.yaml
+++ b/helm/kube-linstor/templates/controller-rbac.yaml
@@ -16,10 +16,12 @@ rules:
   - apiGroups: [""]
     resources: ["endpoints", "endpoints/restricted"]
     verbs: ["create", "patch", "update"]
+  {{- if .Values.podSecurityPolicy.enabled }}
   - apiGroups: ["extensions"]
     resources: ["podsecuritypolicies"]
     resourceNames: ["{{ $fullName }}"]
     verbs: ["use"]
+  {{- end }}
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/kube-linstor/templates/csi-controller-rbac.yaml
+++ b/helm/kube-linstor/templates/csi-controller-rbac.yaml
@@ -74,6 +74,10 @@ rules:
     resources: ["leases"]
     verbs: ["get", "update"]
     resourceNames: ["linstor-csi-linbit-com"]
+  - apiGroups: ["extensions"]
+    resources: ["podsecuritypolicies"]
+    resourceNames: ["{{ $fullName }}"]
+    verbs: ["use"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/helm/kube-linstor/templates/csi-controller-rbac.yaml
+++ b/helm/kube-linstor/templates/csi-controller-rbac.yaml
@@ -74,10 +74,12 @@ rules:
     resources: ["leases"]
     verbs: ["get", "update"]
     resourceNames: ["linstor-csi-linbit-com"]
+  {{- if .Values.podSecurityPolicy.enabled }}
   - apiGroups: ["extensions"]
     resources: ["podsecuritypolicies"]
     resourceNames: ["{{ $fullName }}"]
     verbs: ["use"]
+    {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/helm/kube-linstor/templates/csi-node-rbac.yaml
+++ b/helm/kube-linstor/templates/csi-node-rbac.yaml
@@ -22,6 +22,10 @@ subjects:
 - kind: ServiceAccount
   name: {{ $fullName }}-csi-node-sa
   namespace: {{ .Release.Namespace }}
+- apiGroups: ["extensions"]
+  resources: ["podsecuritypolicies"]
+  resourceNames: ["{{ $fullName }}"]
+  verbs: ["use"]
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/helm/kube-linstor/templates/csi-node-rbac.yaml
+++ b/helm/kube-linstor/templates/csi-node-rbac.yaml
@@ -9,6 +9,10 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: ["extensions"]
+    resources: ["podsecuritypolicies"]
+    resourceNames: ["{{ $fullName }}"]
+    verbs: ["use"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -22,10 +26,6 @@ subjects:
 - kind: ServiceAccount
   name: {{ $fullName }}-csi-node-sa
   namespace: {{ .Release.Namespace }}
-- apiGroups: ["extensions"]
-  resources: ["podsecuritypolicies"]
-  resourceNames: ["{{ $fullName }}"]
-  verbs: ["use"]
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/helm/kube-linstor/templates/csi-node-rbac.yaml
+++ b/helm/kube-linstor/templates/csi-node-rbac.yaml
@@ -9,10 +9,12 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]
+  {{- if .Values.podSecurityPolicy.enabled }}
   - apiGroups: ["extensions"]
     resources: ["podsecuritypolicies"]
     resourceNames: ["{{ $fullName }}"]
     verbs: ["use"]
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/helm/kube-linstor/templates/ha-controller-rbac.yaml
+++ b/helm/kube-linstor/templates/ha-controller-rbac.yaml
@@ -25,6 +25,10 @@ rules:
     resources: ["leases"]
     verbs: ["get", "update"]
     resourceNames: ["{{ $fullName }}-ha-controller"]
+  - apiGroups: ["extensions"]
+    resources: ["podsecuritypolicies"]
+    resourceNames: ["{{ $fullName }}"]
+    verbs: ["use"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -38,6 +42,10 @@ subjects:
   - kind: ServiceAccount
     name: {{ $fullName }}-ha-controller
     namespace: {{ .Release.Namespace }}
+  - apiGroups: ["extensions"]
+    resources: ["podsecuritypolicies"]
+    resourceNames: ["{{ $fullName }}"]
+    verbs: ["use"]
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/helm/kube-linstor/templates/ha-controller-rbac.yaml
+++ b/helm/kube-linstor/templates/ha-controller-rbac.yaml
@@ -29,6 +29,10 @@ rules:
     resources: ["podsecuritypolicies"]
     resourceNames: ["{{ $fullName }}"]
     verbs: ["use"]
+  - apiGroups: ["extensions"]
+    resources: ["podsecuritypolicies"]
+    resourceNames: ["{{ $fullName }}"]
+    verbs: ["use"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -42,10 +46,6 @@ subjects:
   - kind: ServiceAccount
     name: {{ $fullName }}-ha-controller
     namespace: {{ .Release.Namespace }}
-  - apiGroups: ["extensions"]
-    resources: ["podsecuritypolicies"]
-    resourceNames: ["{{ $fullName }}"]
-    verbs: ["use"]
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/helm/kube-linstor/templates/ha-controller-rbac.yaml
+++ b/helm/kube-linstor/templates/ha-controller-rbac.yaml
@@ -25,6 +25,7 @@ rules:
     resources: ["leases"]
     verbs: ["get", "update"]
     resourceNames: ["{{ $fullName }}-ha-controller"]
+  {{- if .Values.podSecurityPolicy.enabled }}
   - apiGroups: ["extensions"]
     resources: ["podsecuritypolicies"]
     resourceNames: ["{{ $fullName }}"]
@@ -33,6 +34,7 @@ rules:
     resources: ["podsecuritypolicies"]
     resourceNames: ["{{ $fullName }}"]
     verbs: ["use"]
+  {{- end }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/kube-linstor/templates/podsecuritypolicy.yaml
+++ b/helm/kube-linstor/templates/podsecuritypolicy.yaml
@@ -1,0 +1,28 @@
+{{- $fullName := include "linstor.fullname" . -}}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ $fullName }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+    - '*'
+  fsGroup:
+    rule: RunAsAny
+  hostIPC: true
+  hostNetwork: true
+  hostPID: true
+  hostPorts:
+    - max: 65535
+      min: 0
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+    - '*'

--- a/helm/kube-linstor/templates/podsecuritypolicy.yaml
+++ b/helm/kube-linstor/templates/podsecuritypolicy.yaml
@@ -1,4 +1,5 @@
 {{- $fullName := include "linstor.fullname" . -}}
+{{- if .Values.podSecurityPolicy.enabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -26,3 +27,4 @@ spec:
     rule: RunAsAny
   volumes:
     - '*'
+{{- end }}

--- a/helm/kube-linstor/templates/satellite-daemonset.yaml
+++ b/helm/kube-linstor/templates/satellite-daemonset.yaml
@@ -131,6 +131,7 @@ spec:
       hostPID: true
       imagePullSecrets:
         {{- toYaml .Values.satellite.image.pullSecrets | nindent 8 }}
+      serviceAccountName: {{ $fullName }}-satellite-sa
       priorityClassName: system-node-critical
       {{- with .Values.satellite.nodeSelector }}
       nodeSelector:

--- a/helm/kube-linstor/templates/satellite-daemonset.yaml
+++ b/helm/kube-linstor/templates/satellite-daemonset.yaml
@@ -131,7 +131,9 @@ spec:
       hostPID: true
       imagePullSecrets:
         {{- toYaml .Values.satellite.image.pullSecrets | nindent 8 }}
+      {{- if .Values.podSecurityPolicy.enabled }}
       serviceAccountName: {{ $fullName }}-satellite-sa
+      {{- end }}
       priorityClassName: system-node-critical
       {{- with .Values.satellite.nodeSelector }}
       nodeSelector:

--- a/helm/kube-linstor/templates/satellite-rbac.yaml
+++ b/helm/kube-linstor/templates/satellite-rbac.yaml
@@ -1,0 +1,8 @@
+{{- $fullName := include "linstor.fullname" . -}}
+{{- if .Values.satellite.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $fullName }}-satellite-sa
+{{- end }}

--- a/helm/kube-linstor/templates/satellite-rbac.yaml
+++ b/helm/kube-linstor/templates/satellite-rbac.yaml
@@ -5,4 +5,26 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ $fullName }}-satellite-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $fullName }}-satellite-role
+rules:
+  - apiGroups: ["extensions"]
+    resources: ["podsecuritypolicies"]
+    resourceNames: ["{{ $fullName }}"]
+    verbs: ["use"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ $fullName }}-satellite-binding
+roleRef:
+  kind: Role
+  name: {{ $fullName }}-satellite-role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: {{ $fullName }}-satellite-sa
 {{- end }}

--- a/helm/kube-linstor/templates/satellite-rbac.yaml
+++ b/helm/kube-linstor/templates/satellite-rbac.yaml
@@ -1,5 +1,5 @@
 {{- $fullName := include "linstor.fullname" . -}}
-{{- if .Values.satellite.enabled }}
+{{- if and .Values.satellite.enabled .Values.podSecurityPolicy.enabled }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/helm/kube-linstor/templates/stork-scheduler-rbac.yaml
+++ b/helm/kube-linstor/templates/stork-scheduler-rbac.yaml
@@ -58,6 +58,10 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "create", "update"]
+  - apiGroups: ["extensions"]
+    resources: ["podsecuritypolicies"]
+    resourceNames: ["{{ $fullName }}"]
+    verbs: ["use"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/kube-linstor/templates/stork-scheduler-rbac.yaml
+++ b/helm/kube-linstor/templates/stork-scheduler-rbac.yaml
@@ -58,10 +58,12 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "create", "update"]
+  {{- if .Values.podSecurityPolicy.enabled }}
   - apiGroups: ["extensions"]
     resources: ["podsecuritypolicies"]
     resourceNames: ["{{ $fullName }}"]
     verbs: ["use"]
+  {{- end }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Lokomotive clusters have PodSecurityPolicy (PSP) enabled by default so I need to apply to satellite containers a permissive PSP.