### PR TITLE
Update csi driver api version

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Containerized Linstor Storage easy to run in your Kubernetes cluster.
 
 ## Requirements
 
-* Working Kubernetes cluster (`v1.17` or higher).
+* Working Kubernetes cluster (`v1.18` or higher).
 * DRBD9 kernel module installed on each satellite node.
 * PostgeSQL database / etcd or any other backing store for redundancy.
 * [Snapshot Controller](https://kubernetes-csi.github.io/docs/snapshot-controller.html#snapshot-controller) (optional)

--- a/helm/kube-linstor/templates/csi-driver.yaml
+++ b/helm/kube-linstor/templates/csi-driver.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.csi.enabled }}
 ---
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: linstor.csi.linbit.com


### PR DESCRIPTION
Warning is self explanatory : `storage.k8s.io/v1beta1 CSIDriver is deprecated in v1.19+, unavailable in v1.22+; use storage.k8s.io/v1 CSIDriver`
⚠️ It will set minimum required K8s version to 1.18