### PR TITLE
Release 1.11.1-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,23 +136,19 @@ https://kubernetes-csi.github.io/docs/snapshot-controller.html#deployment
 
 ## Usage
 
-You can get interactive linstor shell by simple exec into **linstor-controller** container:
+The satellite nodes will register themselves on controller automatically by init-container.
+
+You can get interactive linstor shell by simple exec into **linstor-controller** pod:
 
 ```bash
-kubectl exec -ti -n linstor deploy/linstor-controller -- linstor
+kubectl exec -ti -n linstor deploy/linstor-controller -- linstor interactive
 ```
 
-Refer to [official linstor documentation](https://docs.linbit.com/linbit-docs/) to define nodes and create new resources.
+Refer to [official linstor documentation](https://docs.linbit.com/docs/linstor-guide/) to define ***storage pools*** on them and configure ***resource groups***.
 
 #### SSL notes
 
 This chart enables SSL encryption for control-plane by default. It does not affect the DRBD performance but makes your LINSTOR setup more secure.
-
-Any way, do not forget to specify `--communicates-type SSL` option during node creation, example:
-
-```bash
-linstor node create alpha 1.2.3.4 --communication-type SSL
-```
 
 If you want to have external access, you need to download certificates for linstor client:
 
@@ -162,12 +158,6 @@ kubectl get secrets --namespace linstor linstor-client-tls \
 ```
 
 Then follow [official linstor documentation](https://www.linbit.com/drbd-user-guide/users-guide-linstor/#s-rest-api-https-restricted-client) to configure the client.
-
-> **_NOTE:_**
-> v1.9.0 release also introduce shorter release name: `linstor-` instead of `linstor-linstor-`, this change shouldn't break anything, however it will regenerate SSL certificates.
-If you are using LINSTOR API externally, you might need to update the client certificates or keep the old release name prefix by specifying `--set fullnameOverride=linstor-linstor` option.
->
-> See [#18](https://github.com/kvaps/kube-linstor/issues/18) for more details.
 
 ## Additional Information
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ helm repo add kvaps https://kvaps.github.io/charts
 
   ```bash
   # download example values
-  curl -LO https://github.com/kvaps/kube-linstor/raw/v1.11.1/examples/linstor-db.yaml
+  curl -LO https://github.com/kvaps/kube-linstor/raw/v1.11.1-1/examples/linstor-db.yaml
 
   # install release
   helm install linstor-db kvaps/stolon \
@@ -118,10 +118,10 @@ helm repo add kvaps https://kvaps.github.io/charts
 
   ```bash
   # download example values
-  curl -LO https://github.com/kvaps/kube-linstor/raw/v1.11.1/examples/linstor.yaml
+  curl -LO https://github.com/kvaps/kube-linstor/raw/v1.11.1-1/examples/linstor.yaml
 
   # install release
-  helm install linstor kvaps/linstor --version 1.11.1 \
+  helm install linstor kvaps/linstor --version 1.11.1-1 \
     --namespace linstor \
     -f linstor.yaml
   ```

--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -47,7 +47,7 @@ Anyway you can perform upgrade by simple replacing resources in your Kubernetes 
 ***Helm way:***
 
   ```bash
-  helm upgrade linstor kvaps/linstor --version 1.11.1 --namespace linstor -f linstor.yaml
+  helm upgrade linstor kvaps/linstor --version 1.11.1-1 --namespace linstor -f linstor.yaml
   ```
 
 ***Templated manifests:***

--- a/helm/kube-linstor/Chart.yaml
+++ b/helm/kube-linstor/Chart.yaml
@@ -1,7 +1,7 @@
 name: linstor
 description: Containerized LINSTOR SDS for Kubernetes, ready for production use.
 version: 1.11.1
-appVersion: 1.11.1
+appVersion: 1.11.1-1
 icon: https://hsto.org/getpro/habr/post_images/e47/594/c07/e47594c0721332fb46493d20339bb1be.png
 keywords:
   - linstor

--- a/helm/kube-linstor/templates/satellite-daemonset.yaml
+++ b/helm/kube-linstor/templates/satellite-daemonset.yaml
@@ -15,7 +15,7 @@ spec:
       labels:
         app: {{ $fullName }}-satellite
     spec:
-      {{- if or .Values.satellite.ssl.enabled .Values.satellite.overwriteDrbdConf }}
+      {{- if or .Values.satellite.ssl.enabled .Values.satellite.overwriteDrbdConf .Values.satellite.autoJoinNodes }}
       initContainers:
       {{- if .Values.satellite.ssl.enabled }}
       - name: load-certs
@@ -65,6 +65,50 @@ spec:
           mountPath: /etc/drbd.d
         - name: usr-local-sbin
           mountPath: /host-bin
+      {{- end }}
+      {{- if .Values.satellite.autoJoinNodes }}
+      - name: join-cluster
+        {{- with .Values.satellite.image }}
+        image: "{{ .repository }}{{ if .digest }}@{{ .digest }}{{ else }}:{{ .tag }}{{ end }}"
+        imagePullPolicy: {{ .PullPolicy }}
+        {{- end }}
+        command:
+          - /bin/sh
+          - -exc
+          - |
+            apk add --no-cache curl
+            {{- if .Values.controller.ssl.enabled }}
+            curl -s -f --cacert /tls/client/ca.crt --cert /tls/client/tls.crt --key /tls/client/tls.key https://{{ $fullName }}-controller:{{ .Values.controller.ssl.port }}/v1/nodes/${NODE_NAME} && exit 0
+            curl -s -f --cacert /tls/client/ca.crt --cert /tls/client/tls.crt --key /tls/client/tls.key -H "Content-Type: application/json" -d "{\"name\": \"${NODE_NAME}\", \"type\": \"satellite\", \"net_interfaces\": [{\"name\": \"default\", \"address\": \"${NODE_IP}\", \"satellite_port\": ${NODE_PORT}, \"satellite_encryption_type\": \"${NODE_ENCRYPTION_TYPE}\"}]}" https://{{ $fullName }}-controller:{{ .Values.controller.ssl.port }}/v1/nodes
+            {{- else }}
+            curl -s -f http://{{ $fullName }}-controller:{{ .Values.controller.port }}/v1/nodes/${NODE_NAME} && exit 0
+            curl -s -f -H "Content-Type: application/json" -d "{\"name\": \"${NODE_NAME}\", \"type\": \"satellite\", \"net_interfaces\": [{\"name\": \"default\", \"address\": \"${NODE_IP}\", \"satellite_port\": ${NODE_PORT}, \"satellite_encryption_type\": \"${NODE_ENCRYPTION_TYPE}\"}]}" http://{{ $fullName }}-controller:{{ .Values.controller.port }}/v1/nodes
+            {{- end }}
+        env:
+          {{- if .Values.satellite.ssl.enabled }}
+          - name: NODE_PORT
+            value: "{{ .Values.satellite.ssl.port }}"
+          - name: NODE_ENCRYPTION_TYPE
+            value: "ssl"
+          {{- else }}
+          - name: NODE_PORT
+            value: "{{ .Values.satellite.port }}"
+          - name: NODE_ENCRYPTION_TYPE
+            value: "Plain"
+          {{- end }}
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: NODE_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+        {{- if .Values.controller.ssl.enabled }}
+        volumeMounts:
+          - name: client-tls
+            mountPath: /tls/client
+        {{- end }}
       {{- end }}
       {{- end }}
       containers:
@@ -129,6 +173,7 @@ spec:
       hostIPC: true
       hostNetwork: true
       hostPID: true
+      dnsPolicy: ClusterFirstWithHostNet
       imagePullSecrets:
         {{- toYaml .Values.satellite.image.pullSecrets | nindent 8 }}
       {{- if .Values.podSecurityPolicy.enabled }}
@@ -187,6 +232,11 @@ spec:
       - name: satellite-tls
         secret:
           secretName: {{ $fullName }}-satellite-tls
+      {{- end }}
+      {{- if and .Values.controller.ssl.enabled .Values.satellite.autoJoinNodes }}
+      - name: client-tls
+        secret:
+          secretName: {{ $fullName }}-client-tls
       {{- end }}
       - name: logs
         hostPath:

--- a/helm/kube-linstor/values.yaml
+++ b/helm/kube-linstor/values.yaml
@@ -6,8 +6,8 @@
 controller:
   enabled: true
   image:
-    repository: docker.io/kvaps/linstor-controller
-    tag: v1.11.1
+    repository: ghcr.io/kvaps/linstor-controller
+    tag: v1.11.1-1
     pullPolicy: IfNotPresent
     pullSecrets:
       - name: regsecret
@@ -77,8 +77,8 @@ controller:
 satellite:
   enabled: true
   image:
-    repository: docker.io/kvaps/linstor-satellite
-    tag: v1.11.1
+    repository: ghcr.io/kvaps/linstor-satellite
+    tag: v1.11.1-1
     pullPolicy: IfNotPresent
     pullSecrets:
       - name: regsecret
@@ -115,8 +115,8 @@ csi:
     pullSecrets:
       - name: regsecret
     linstorCsiPlugin:
-      repository: docker.io/kvaps/linstor-csi
-      tag: v1.11.1
+      repository: ghcr.io/kvaps/linstor-csi
+      tag: v1.11.1-1
       pullPolicy: IfNotPresent
     csiProvisioner:
       repository: k8s.gcr.io/sig-storage/csi-provisioner
@@ -169,8 +169,8 @@ csi:
 haController:
   enabled: true
   image:
-    repository: docker.io/kvaps/linstor-ha-controller
-    tag: v1.11.1
+    repository: ghcr.io/kvaps/linstor-ha-controller
+    tag: v1.11.1-1
     pullPolicy: IfNotPresent
     pullSecrets:
       - name: regsecret
@@ -194,8 +194,8 @@ haController:
 stork:
   enabled: true
   image:
-    repository: docker.io/kvaps/linstor-stork
-    tag: v1.11.1
+    repository: ghcr.io/kvaps/linstor-stork
+    tag: v1.11.1-1
     pullPolicy: IfNotPresent
     pullSecrets:
       - name: regsecret

--- a/helm/kube-linstor/values.yaml
+++ b/helm/kube-linstor/values.yaml
@@ -92,6 +92,9 @@ satellite:
   # usage-count=no and udev-always-use-vnr options by default
   overwriteDrbdConf: true
 
+  # Join the nodes automatically at init
+  autoJoinNodes: true
+
   # How many nodes can simultaneously download new image
   update:
     maxUnavailable: 40


### PR DESCRIPTION
This release includes many features implemented by @jbanety: automatically join nodes, etcd support and so on.
Many thanks for this contribution! 🎉🎉🎉

**Features:**

* Migrate images from [docker.io](https://hub.docker.com/search?q=kvaps%2Flinstor&type=image) to [ghcr.io](https://github.com/kvaps?tab=packages&q=linstor) registry
* Automatically join nodes (https://github.com/kvaps/kube-linstor/pull/26)
* Add secured etcd support (https://github.com/kvaps/kube-linstor/pull/27)
* Update csi driver api version (https://github.com/kvaps/kube-linstor/pull/25)
* Add PodSecurityPolicy support (https://github.com/kvaps/kube-linstor/pull/24)
* Update drbd-utils and stork versions (https://github.com/kvaps/kube-linstor/pull/29)

⚠️ Minimal required K8s version updated to 1.18