### PR TITLE
Add code to ensure start order between controller/satellite/csi-node

### DIFF
--- a/helm/kube-linstor/templates/csi-node-daemonset.yaml
+++ b/helm/kube-linstor/templates/csi-node-daemonset.yaml
@@ -16,6 +16,29 @@ spec:
         app: {{ $fullName }}-csi-node
         role: linstor-csi
     spec:
+
+      initContainers:
+        ## Wait for the satellite pod on this node to be ready -- it must be before the CSI node attempts
+        ## to connect to it
+        - name: wait-for-satellite
+          image: bitnami/kubectl
+          imagePullPolicy: {{ .PullPolicy }}
+          command:
+            - /bin/sh
+            - -exc
+            - |
+              echo "[info] waiting for a pod with label [${SATELLITE_LABEL_SELECTOR}] in namespace [${SATELLITE_NAMESPACE}], on node [${NODE_NAME}]"
+              kubectl wait pod -n ${SATELLITE_NAMESPACE} -l ${SATELLITE_LABEL_SELECTOR} --field-selector spec.nodeName=${NODE_NAME} --for=condition=ready
+          env:
+            - name: SATELLITE_LABEL_SELECTOR
+              value: "app={{ $fullName }}-satellite"
+            - name: SATELLITE_NAMESPACE
+              value: {{ .Release.Namespace }}
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+
       containers:
       - name: csi-node-driver-registrar
         {{- with .Values.csi.image.csiNodeDriverRegistrar }}

--- a/helm/kube-linstor/templates/csi-node-rbac.yaml
+++ b/helm/kube-linstor/templates/csi-node-rbac.yaml
@@ -9,6 +9,9 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
   {{- if .Values.podSecurityPolicy.enabled }}
   - apiGroups: ["extensions"]
     resources: ["podsecuritypolicies"]

--- a/helm/kube-linstor/templates/satellite-daemonset.yaml
+++ b/helm/kube-linstor/templates/satellite-daemonset.yaml
@@ -15,8 +15,34 @@ spec:
       labels:
         app: {{ $fullName }}-satellite
     spec:
+
       {{- if or .Values.satellite.ssl.enabled .Values.satellite.overwriteDrbdConf .Values.satellite.autoJoinNodes }}
       initContainers:
+
+        ## Wait for at least one controller to be ready -- a controller must be running for satellite to register with
+        - name: wait-for-controller
+          image: bitnami/kubectl
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -exc
+            - |
+              n=0
+              until [ $n -ge 30 ]; do
+                  REPLICA_COUNT=$(kubectl get deploy/${CONTROLLER_DEPLOYMENT_NAME} -n ${CONTROLLER_NAMESPACE} -o template --template='{{ .status.availableReplicas }}')
+                  if [ "${REPLICA_COUNT}" -gt "0" ] ; then
+                      echo "[info] found ${REPLICA_COUNT} available replicas."
+                      break
+                  fi
+                  echo -n "[info] waiting 10 seconds before trying again..."
+                  sleep 10
+              done
+          env:
+            - name: CONTROLLER_DEPLOYMENT_NAME
+              value: "{{ $fullName }}-controller"
+            - name: CONTROLLER_NAMESPACE
+              value: {{ .Release.Namespace }}
+
       {{- if .Values.satellite.ssl.enabled }}
       - name: load-certs
         {{- with .Values.satellite.image }}
@@ -42,6 +68,7 @@ spec:
         - name: satellite-tls
           mountPath: /tls/satellite
       {{- end }}
+
       {{- if .Values.satellite.overwriteDrbdConf }}
       - command:
         - /bin/sh
@@ -66,6 +93,7 @@ spec:
         - name: usr-local-sbin
           mountPath: /host-bin
       {{- end }}
+
       {{- if .Values.satellite.autoJoinNodes }}
       - name: join-cluster
         {{- with .Values.satellite.image }}
@@ -110,6 +138,7 @@ spec:
         {{- end }}
       {{- end }}
       {{- end }}
+
       containers:
       - name: linstor-satellite
         {{- with .Values.satellite.image }}

--- a/helm/kube-linstor/templates/satellite-rbac.yaml
+++ b/helm/kube-linstor/templates/satellite-rbac.yaml
@@ -15,6 +15,10 @@ rules:
     resources: ["podsecuritypolicies"]
     resourceNames: ["{{ $fullName }}"]
     verbs: ["use"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    resourceNames: ["{{ $fullName }}-controller"]
+    verbs: ["get"]
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
I found that after trying to set up `kube-linstor` start order (especially after restart) was causing the node to not get registered. As far as I can tell, the order must be -- `controller`>`satellite`>`csi-node`.  

If they start in the wrong order, the storage pool (which is currently implemented as a `initContainer` for me, see https://github.com/kvaps/kube-linstor/pull/31) does not get registered properly. Short of building in a CRD/control loop I don't think there's much you can do about this -- I couldn't find a way to pre-configure the storage pool layout of `linstor` with a file (is this possible? surely it is?)

Signed-off-by: vados <vados@vadosware.io>